### PR TITLE
This link will always point to the latest release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 Introduction-to-Autonomous-Robots
 =================================
 
-An open textbook focusing on computational principles of autonomous robots. The book is released under Creative Commons 2.0, available as [PDF](https://github.com/correll/Introduction-to-Autonomous-Robots/releases/download/v1.7/book.pdf) ("releases" tab) and via Amazon on-demand printing:
+An open textbook focusing on computational principles of autonomous robots. The book is released under Creative Commons 2.0, available as a [PDF](https://github.com/correll/Introduction-to-Autonomous-Robots/releases/latest) ("releases" tab) and via Amazon on-demand printing:
 http://www.amazon.com/Introduction-Autonomous-Robots-Nikolaus-Correll/dp/1493773070 


### PR DESCRIPTION
Unfortunately, this doesn't _directly_ link the PDF, but I'm pretty sure people will see the "book.pdf" link under "Downloads." 

(See http://stackoverflow.com/q/21439239/1110928 for information about this link.)
