### PR TITLE
text changes in sensor chapter

### DIFF
--- a/chapters/sensors.tex
+++ b/chapters/sensors.tex
@@ -121,7 +121,7 @@ A sensor's precision \index{Precision (sensor)} instead is given by the ratio of
 \begin{figure}
 	\centering
 		\includegraphics[width=0.9\textwidth]{figs/precisionvsaccuracy.png}
-	\caption{From left to right, the cross corresponds to the true value of the signal: neither precise nor accurate, precise, but not accurate, accurate, but not precise, and accurate and precise. 
+	\caption{From left to right, the cross corresponds to the true value of the signal: neither precise nor accurate, precise but not accurate, accurate but not precise, accurate and precise. 
 	\label{fig:precision}}
 \end{figure}
 

--- a/chapters/sensors.tex
+++ b/chapters/sensors.tex
@@ -134,7 +134,7 @@ The speed at which a sensor can provide measurements is known as its \index{Band
 \begin{itemize}
 \item Most of a robot's sensors either address the problem of robot localization or localizing and recognizing objects in its vicinity.
 \item Each sensors has advantages and drawbacks that are quantified in its range, precision, accuracy, and bandwidth. Therefore, robust solutions to a problem can only be achieved by combining multiple sensors with differing operation principles.
-\item Solid-state sensors (i.e. without mechanical parts) can be miniaturized and cheaply manufactured in quantity. This has enabled a series of affordable IMUs and 3D depth sensors that will provide the data basis for localization and object recognition on mass-market robotic systems
+\item Solid-state sensors (i.e. without mechanical parts) can be miniaturized and cheaply manufactured in quantity. This has enabled a series of affordable IMUs and 3D depth sensors that will provide the data basis for localization and object recognition on mass-market robotic systems.
 \end{itemize} 
 
 \section*{Exercises}\small


### PR DESCRIPTION
change 1: more understandable comma placement
change 2: missing point in sentence

By the way, there are two PNG files missing in the repo for the sensor chapter:
\includegraphics[width=0.8\textwidth]{figs/epuckirsensor.png}
\includegraphics[width=\textwidth]{figs/structuredlight.png}
