### PR TITLE
text structure: made it clearear

### DIFF
--- a/chapters/localization.tex
+++ b/chapters/localization.tex
@@ -123,10 +123,9 @@ Together, the likelihood that the robot got from position $2-3$ to position $4$ 
 
 The robot could also move from $1-2$ to $2$, $2-3$, $3$, $3-4$ or $4$. We can evaluate these hypotheses in a similar way:
 \begin{itemize}
-\item The chance that it correctly detects the open hallway and door at position $2$ is $0.9*0.9$, so the chance to be at position $2$ is
-$0.8*0.9*0.9=64\%$.
-\item The chance to have seen an open door instead of a wall at $2-3$, $3$, and $3-4$ is zero, so the robot cannot have ended up at these positions.
-\item In order to reach position $4$, the robot must not have seen the hallway on its left and the open door to its right when passing position $2$. The probability for this is $0.001*0.05$. The robot must then have detected nothing at $2-3$ ($0.7*0.7$), nothing at $3$ ($0.05*0.7$), nothing at $3-4$ ($0.7*0.7$), and finally mistaken the hallway on its right for an open door at position $4$ ($0.9*0.1$). Multiplied together, this outcome is very unlikely.
+\item The chance that it correctly detects the open hallway and door at position $2$ is $0.9*0.9$, so the chance to be at position $2$, having started at $1-2$, is $0.8*0.9*0.9=64\%$.
+\item The robot cannot have ended up at position $2-3$, $3$, and $3-4$ because the chance of seeing an open door instead of a wall on the right side is zero in all these cases.
+\item In order to reach position $4$, the robot must have started at $1-2$ has a chance of $0.8$. The robot must not have seen the hallway on its left and the open door to its right when passing position $2$. The probability for this is $0.001*0.05$. The robot must then have detected nothing at $2-3$ ($0.7*0.7$), nothing at $3$ ($0.05*0.7$), nothing at $3-4$ ($0.7*0.7$), and finally mistaken the hallway on its right for an open door at position $4$ ($0.9*0.1$). Multiplied together, this outcome is very unlikely.
 \end{itemize}
 
 Given this information, we can now calculate the posterior probability to be at a certain location on the topological map by adding up the probabilities for every possible path to get there. 


### PR DESCRIPTION
This Pull request is about clarity of text in the Markov Localization section:
When I first read this section it was not very clear to me that the first example of Markov Localization describes only one hypothesis, whereas the second example evaluates multiple hypothesis.
In order to make this clearer I have:
- (bullet 1 and 3) added text to each bullet of the second example pointing out that the robot starts at position 1-2 (aiming towards distinguishing One Hypothesis vs Multiple Hypotheses evaluation)
- (bullet 2) changed the order of the sentence aiming here again to a "Multiple Hypotheses" evaluation. 
