### PR TITLE
Fix equation for phi_1 and phi_2

### DIFF
--- a/chapters/forwardkinematics1.tex
+++ b/chapters/forwardkinematics1.tex
@@ -373,8 +373,8 @@ Let the car have the shape of a box with length $L$ between rear and front axis.
 
 The angles of the left and the right wheel, $ \phi_l$ and $ \phi_r$ can be calculated using the fact that all wheels of the car rotate around circles with a common center point. With the distance between the two front wheels $l$, we can write
 \begin{eqnarray}
-\frac{L}{R-l/2}&=\tan{(\pi/2-\phi_r)}\\
-\frac{L}{R+l/2}&=\tan{(\pi/2-\phi_l)}
+\frac{L}{R-l/2}&=\tan{(\phi_r)}\\
+\frac{L}{R+l/2}&=\tan{(\phi_l)}
 \end{eqnarray}
 This is important, as it allows us to calculate the resulting wheel angles resulting from a specific angle $\phi$ and test whether they are within the constraints of the actual vehicle.
 


### PR DESCRIPTION
Assuming phi_1 and phi_2 are both angles moving tangentially to their respective circles, they should be the same equation as phi:
phi = l/R

Except in the left wheel, the new distance from the origin should be  R-l/2.

The right wheel has the same characteristics, except its distance from the origin should be R + l/2.

Substituting these new values for R out, we get:
phi_r = l/(R+l/2)
phi_l = l/(R-l/2)

This other site came to the same conclusion, and has a graphic that includes phi_l and phi_r that may be useful to use if licencing permits.

https://www.xarg.org/book/kinematics/ackerman-steering/