### PR TITLE
Fix homogeneous transformation eq., typos, and remark about last row of ho. tr. matrix

### DIFF
--- a/chapters/forwardkinematics1.tex
+++ b/chapters/forwardkinematics1.tex
@@ -489,7 +489,7 @@ R_x(\alpha_n)=\left(
 \end{equation}
 These are a translation of $d_n$ along the previous z-axis ($T_z'(d_n)$), a rotation of $\theta_n$ about the previous z-axis ($R_z'(\theta_n)$), a translation of $r_n$ along the new $x$-axis ($T_x(r_n)$)and a rotation of $\alpha_n$ around the new $x$-axis ($R_x(\alpha_n)$).
 
-Like for any homogeneous transfrom, the inverse $_{n-1}^nT^{-1}n$ is given by
+Like for any homogeneous transform, the inverse $_{n-1}^nT^{-1}n$ is given by
 \begin{equation}
 ^{n-1}_nT=\left(
 \begin{array}{c|c}

--- a/chapters/forwardkinematics1.tex
+++ b/chapters/forwardkinematics1.tex
@@ -107,7 +107,7 @@ Using this notation, we can see that leading subscripts cancel the leading super
 \end{equation}
 In order to do this, we need to introduce a 4x1 position vector such that
 \begin{equation}
-\left[\begin{array}{c}^AQ\\\end{array}\right]=\left[\begin{array}{ccc|c} & ^A_BR & & ^AP \\\hline 0 & 0 & 0 & 1\end{array}\right]\left[\begin{array}{c}^BQ\\1\end{array}\right]
+\left[\begin{array}{c}^AQ\\1\end{array}\right]=\left[\begin{array}{ccc|c} & ^A_BR & & ^AP \\\hline 0 & 0 & 0 & 1\end{array}\right]\left[\begin{array}{c}^BQ\\1\end{array}\right]
 \end{equation}
 and $^A_BT$ is a 4x4 matrix.  Note that the added `1`s and $ [0 0 0 1]$ do not affect the other entries in the matrix during matrix multiplication. A 4x4 matrix of this form is called a \emph{homogenous transform}.\index{Homogenous Transform}
 

--- a/chapters/forwardkinematics3.tex
+++ b/chapters/forwardkinematics3.tex
@@ -21,7 +21,7 @@ The inverse kinematics problem can then be formulated as feedback control proble
  \end{enumerate}
 \item Assume two coordinate systems that are co-located in the same origin, but rotated around the z-axis by the angle $\alpha$. Derive the rotation matrix from one coordinate system into the other and verify that each entry of this matrix is indeed the scalar product of each basis vector of one coordinate system with every other basis vector in the second coordinate system.
 \item Consider two coordinate systems $\{B\}$ and $\{C\}$, whose orientation is given by the rotation matrix $^C_BR$ and have distance $^BP$. Provide the homogenous transform $^C_BT$ and its inverse $^B_CT$.
-\item Consider the frame $\{B\}$ that is defined with respect to frame $\{A\}$ as $\{B\}=\{^A_BR, ^AP\}$. Provide a homogeneous transfrom from $\{A\}$ to $\{B\}$.
+\item Consider the frame $\{B\}$ that is defined with respect to frame $\{A\}$ as $\{B\}=\{^A_BR, ^AP\}$. Provide a homogeneous transform from $\{A\}$ to $\{B\}$.
 \item Program a simple application that displays a 2D (or 3D) coordinate system and add the ability to move and turn the coordinate system using your keyboard.
 \end{enumerate}
 


### PR DESCRIPTION
Here are minor fixes @correll . Can you please check them?

I also saw that the last row `[0 0 0 1]` of the transformation matrix is not required to integrate translation and rotation in a single operation. We could throw the last row away and the 3x4 matrix would still rotate and translate. Am I right?

 It would be great to clarify why we still take the 4x4 instead of 3x4 matrix.